### PR TITLE
Fixing errors in loaders and improving splitters

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,647 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.12
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=1
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero,
+        use-symbolic-message-instead
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=cv2.*
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/document_loaders/parsers.py
+++ b/document_loaders/parsers.py
@@ -16,13 +16,15 @@ from pypdf._page import PageObject
 from PIL import Image, ImageDraw
 import pytesseract
 import pdf2image
-import matplotlib.pyplot as plt
+import cv2
+from matplotlib import pyplot as plt
 import pandas as pd
+import numpy as np
 import psutil
 import pdfplumber
 
 from .visitors import PageTextVisitor
-from .processors import get_data_inside_boundaries
+from .processors import get_data_inside_boundaries, get_lines_from_image
 
 @dataclass
 class GroupState:
@@ -30,10 +32,9 @@ class GroupState:
 
     line_cols: dict[str, dict[str, int]]
     group_cols: dict[str, dict[str, int]]
-    prev_num_cols: int|None
+    prev_values: dict[str, int|bool|None]
     centered: dict[str, bool|None]
     pass_through_center: dict[str, bool|None]
-    prev_new_group: bool
     tolerance: float
     group_num: int
 
@@ -60,7 +61,9 @@ class PypdfPage():
                 (1.0 - boundaries['bottom']) * page_height
             )
         else:
-            self.visitor.set_boundaries(*self.page['/ArtBox'])
+            # PDF Y-axis is inverted
+            left, top, right, bottom = self.page['/ArtBox']
+            self.visitor.set_boundaries(left=left, top=bottom, right=right, bottom=top)
         text = self.page.extract_text(visitor_text=self.visitor.visitor_text)
 
         return self.__remove_out_of_bounds_text(text)
@@ -136,8 +139,10 @@ class DataReconstructor():
     adding columns to the data.
     """
 
-    def __init__(self, data: pd.DataFrame, writable_boundaries:tuple[float, float, float, float]):
+    def __init__(self, data: pd.DataFrame, writable_boundaries:tuple[float, float, float, float],
+                 lines:dict[str,np.array]):
         self.data = data.copy()
+        self.lines = lines
 
         if 'right' not in self.data:
             self.data['right'] = self.data['left'] + self.data['width']
@@ -169,9 +174,10 @@ class DataReconstructor():
         for word_idx, word in words.iterrows():
             word_top = word['top']
             word_bottom = word['top'] + word['height']
-            word_center = word['top'] + word['height'] * 0.5
+            word_height = word['bottom'] - word['top']
 
-            if current_min_y < word_center < current_max_y: # Is same line
+            if (current_min_y + word_height * 0.4 < word_bottom
+                and current_max_y - word_height * 0.4 > word_top): # Is same line
                 current_min_y = min(current_min_y, word_top)
                 current_max_y = max(current_max_y, word_bottom)
             else: # Is another line
@@ -182,7 +188,7 @@ class DataReconstructor():
 
     def __assign_column_number(self, min_words_per_col:int=1):
         self.data['column'] = pd.Series(dtype='int')
-        tolerance = self.writable_width * 0.025
+        tolerance = self.writable_width * 0.04
 
         for _, line_words in self.data.groupby('line'):
             col_number = -1
@@ -256,12 +262,11 @@ class DataReconstructor():
         state = GroupState(
             line_cols=None,
             group_cols=None,
-            prev_num_cols=None,
+            prev_values={'num_cols': None, 'new_group': False},
             centered={'prev': None, 'curr': None},
             pass_through_center={'prev': None, 'curr': None},
-            prev_new_group=False,
             tolerance=tolerance,
-            group_num=0
+            group_num=0,
         )
 
         for _, line_words in self.data.groupby('line'):
@@ -282,10 +287,10 @@ class DataReconstructor():
             self.data.loc[line_words.index, 'group'] = state.group_num
 
             # Update tracking variables
-            state.prev_num_cols = len(state.line_cols)
+            state.prev_values['num_cols'] = len(state.line_cols)
             state.centered['prev'] = state.centered['curr']
             state.pass_through_center['prev'] = state.pass_through_center['curr']
-            state.prev_new_group = new_group
+            state.prev_values['new_group'] = new_group
 
             if state.group_cols is None or new_group:
                 state.group_cols = state.line_cols
@@ -298,7 +303,9 @@ class DataReconstructor():
         grouped = line_words.groupby('column').agg({
             'col_position': 'max',
             'left': 'min',
-            'right': 'max'
+            'right': 'max',
+            'top': 'min',
+            'bottom': 'max',
         })
 
         for column, values in grouped.iterrows():
@@ -306,15 +313,23 @@ class DataReconstructor():
                 'position_max': values['col_position'],
                 'minX': values['left'],
                 'maxX': values['right'],
+                'minY': values['top'],
+                'maxY': values['bottom'],
             }
 
         return columns_info
 
     def __is_new_group(self, state:GroupState):
         if (state.group_cols is None or
-            state.prev_num_cols is None or
+            state.prev_values['num_cols'] is None or
             state.centered['prev'] is None):
             return False
+
+        for line in self.lines['horizontal']:
+            for c, l_col in state.line_cols.items():
+                if (c in state.group_cols and
+                    state.group_cols[c]['minY'] < line[0,1] < state.line_cols[c]['maxY']):
+                    return True
 
         if len(state.group_cols) != len(state.line_cols):
             if state.pass_through_center['curr'] or state.pass_through_center['prev']:
@@ -331,7 +346,7 @@ class DataReconstructor():
 
                 if (not self.__columns_wrap_each_other(
                         state.line_cols[l_col], state.group_cols[g_col], state.tolerance) and
-                    not state.prev_new_group):
+                    not state.prev_values['new_group']):
                     return True
         return False
 
@@ -350,6 +365,13 @@ class DataReconstructor():
 
                 group_cols[g_col]['minX'] = min(group_cols[g_col]['minX'], line_cols[l_col]['minX'])
                 group_cols[g_col]['maxX'] = max(group_cols[g_col]['maxX'], line_cols[l_col]['maxX'])
+                group_cols[g_col]['minY'] = min(group_cols[g_col]['minY'], line_cols[l_col]['minY'])
+                group_cols[g_col]['maxY'] = max(group_cols[g_col]['maxY'], line_cols[l_col]['maxY'])
+
+        if len(line_cols) > len(group_cols):
+            for l_col in line_cols:
+                if l_col not in group_cols:
+                    group_cols[l_col] = line_cols[l_col]
 
 class OcrPage():
     """This class stores the information contained in a single page
@@ -361,12 +383,13 @@ class OcrPage():
         self.cache_file = cache_file
 
         self.data = self.__get_data_from_image()
+        self.lines = self.__get_lines_from_image()
         self.width = self.data.loc[0, 'width']
         self.height = self.data.loc[0, 'height']
         self.__normalize_data()
         w_boundaries = self.__get_writable_boundaries()
 
-        reconstructor = DataReconstructor(self.data, w_boundaries)
+        reconstructor = DataReconstructor(self.data, w_boundaries, self.lines)
         self.data = reconstructor.get_reconstructed()
 
     def get_text(self, remove_headers: bool=False, boundaries:dict[str,float]=None) -> str:
@@ -474,11 +497,22 @@ class OcrPage():
 
         return data
 
+    def __get_lines_from_image(self):
+        image = cv2.cvtColor(np.array(self.image), cv2.COLOR_BGR2GRAY)
+        words_data = self.data[self.data['level'] == 5]
+
+        return get_lines_from_image(image, words_data)
+
     def __normalize_data(self):
-        self.data['left'] = self.data['left'] / self.data.loc[0, 'width']
-        self.data['width'] = self.data['width'] / self.data.loc[0, 'width']
-        self.data['top'] = self.data['top'] / self.data.loc[0, 'height']
-        self.data['height'] = self.data['height'] / self.data.loc[0, 'height']
+        width = self.data.loc[0, 'width']
+        height = self.data.loc[0, 'height']
+        self.data['left'] = self.data['left'] / width
+        self.data['width'] = self.data['width'] / width
+        self.data['top'] = self.data['top'] / height
+        self.data['height'] = self.data['height'] / height
+
+        if len(self.lines['horizontal']) > 0:
+            self.lines['horizontal'] = self.lines['horizontal'] / np.array((width, height))
 
     def __get_writable_boundaries(self):
         # There's a block with text ' ' from 0.0 to 1.0, we need to eliminate it
@@ -604,15 +638,17 @@ class PdfPlumberPage():
     methods to process it.
     """
 
-    def __init__(self, page:pdfplumber.page.Page):
+    def __init__(self, page:pdfplumber.page.Page, cache_file:str|None=None):
         self.page = page.dedupe_chars()
+        self.cache_file = cache_file
 
         self.data = self.__get_data_from_page()
+        self.lines = self.__get_lines_from_image()
 
         self.__normalize_data()
 
         w_boundaries = self.__get_writable_boundaries()
-        reconstructor = DataReconstructor(self.data, w_boundaries)
+        reconstructor = DataReconstructor(self.data, w_boundaries, self.lines)
         self.data = reconstructor.get_reconstructed()
 
     def get_text(self, remove_headers: bool=False, boundaries:dict[str,float]=None) -> str:
@@ -684,13 +720,41 @@ class PdfPlumberPage():
 
         return data
 
+    def __get_lines_from_image(self):
+        if not os.path.exists(self.cache_file):
+            return None
+
+        image = cv2.imread(self.cache_file, cv2.IMREAD_GRAYSCALE)
+        words_data = self.data.copy()
+
+        width_rate = image.shape[1] / self.page.width
+        height_rate = image.shape[0] / self.page.height
+        words_data['left'] = (words_data['left'] * width_rate).astype(int)
+        words_data['right'] = (words_data['right'] * width_rate).astype(int)
+        words_data['width'] = (words_data['width'] * width_rate).astype(int)
+        words_data['top'] = (words_data['top'] * height_rate).astype(int)
+        words_data['bottom'] = (words_data['bottom'] * height_rate).astype(int)
+        words_data['height'] = (words_data['height'] * height_rate).astype(int)
+
+        lines = get_lines_from_image(image, words_data)
+
+        if len(lines['horizontal']) > 0:
+            lines['horizontal'] = lines['horizontal'] / width_rate
+
+        return lines
+
     def __normalize_data(self):
-        self.data['left'] = self.data['left'] / self.page.width
-        self.data['right'] = self.data['right'] / self.page.width
-        self.data['width'] = self.data['width'] / self.page.width
-        self.data['top'] = self.data['top'] / self.page.height
-        self.data['bottom'] = self.data['bottom'] / self.page.height
-        self.data['height'] = self.data['height'] / self.page.height
+        width = self.page.width
+        height = self.page.height
+        self.data['left'] = self.data['left'] / width
+        self.data['right'] = self.data['right'] / width
+        self.data['width'] = self.data['width'] / width
+        self.data['top'] = self.data['top'] / height
+        self.data['bottom'] = self.data['bottom'] / height
+        self.data['height'] = self.data['height'] / height
+
+        if len(self.lines['horizontal']) > 0:
+            self.lines['horizontal'] = self.lines['horizontal'] / np.array((width, height))
 
     def __get_writable_boundaries(self):
         min_x = self.data['left'].min()
@@ -709,11 +773,23 @@ class PdfPlumberParser():
     :param file_path: The path of the file to be parsed.
     :type file_path: str
     """
-
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str, cache_dir: str = './.cache', keep_cache:bool = False):
         self.file_path = file_path
+        self.cache_dir = cache_dir
+        self.keep_cache = keep_cache
 
         self.reader = pdfplumber.open(file_path)
+
+        with open(self.file_path, 'rb') as f:
+            file_md5 = hashlib.md5(f.read()).hexdigest()
+        self.cache_subfolder = os.path.join(self.cache_dir, file_md5)
+
+        if not self.__cache_is_valid():
+            self.__create_cache()
+
+    def __del__(self):
+        if not self.keep_cache:
+            self.clear_cache()
 
     def get_raw_text(self, page_separator: str = '\n', remove_headers:bool = False,
                  boundaries:dict[str,float]=None) -> str:
@@ -727,8 +803,8 @@ class PdfPlumberParser():
         :rtype: str
         """
         text = ''
-        for page in self.reader.pages:
-            page = PdfPlumberPage(page)
+        for i, page in enumerate(self.reader.pages, start=1):
+            page = PdfPlumberPage(page, f'{self.cache_subfolder}/0001-{i:02d}.jpg')
             text += page.get_raw_text(remove_headers, boundaries) + page_separator
 
         return text
@@ -745,8 +821,8 @@ class PdfPlumberParser():
         :rtype: str
         """
         text = ''
-        for page in self.reader.pages:
-            page = PdfPlumberPage(page)
+        for i, page in enumerate(self.reader.pages, start=1):
+            page = PdfPlumberPage(page, f'{self.cache_subfolder}/0001-{i:02d}.jpg')
             text += page.get_text(remove_headers, boundaries) + page_separator
 
         return text
@@ -761,9 +837,46 @@ class PdfPlumberParser():
         :return: An Iterator that yields the text of each page at a time
         :rtype: Iterator[PdfPlumberPage]
         """
-        for page in self.reader.pages:
-            yield PdfPlumberPage(page)
+        for i, page in enumerate(self.reader.pages, start=1):
+            yield PdfPlumberPage(page, f'{self.cache_subfolder}/0001-{i:02d}.jpg')
 
     def get_page(self, page_num: int):
         """Return a specific page of the document."""
-        return PdfPlumberPage(self.reader.pages[page_num])
+        return PdfPlumberPage(self.reader.pages[page_num],
+                              f'{self.cache_subfolder}/0001-{page_num+1:02d}.jpg')
+
+    def clear_cache(self):
+        """Delete the cache sub-directory for this file. If main directory is empty then
+        it is deleted aswell."""
+        tmp_cache = f'{self.cache_subfolder}.tmp'
+
+        if os.path.exists(self.cache_subfolder):
+            shutil.rmtree(self.cache_subfolder)
+        if os.path.exists(tmp_cache):
+            shutil.rmtree(tmp_cache)
+
+        if not os.listdir(self.cache_dir):
+            os.rmdir(self.cache_dir)
+
+    def __cache_is_valid(self) -> bool:
+        return os.path.exists(self.cache_subfolder)
+
+    def __create_cache(self):
+        tmp_cache = f'{self.cache_subfolder}.tmp'
+
+        if os.path.exists(self.cache_subfolder):
+            shutil.rmtree(self.cache_subfolder)
+        if os.path.exists(tmp_cache):
+            shutil.rmtree(tmp_cache)
+
+        os.makedirs(tmp_cache, exist_ok=True)
+
+        images = pdf2image.convert_from_path(self.file_path,
+                                        output_folder=tmp_cache,
+                                        fmt='jpeg',
+                                        dpi=1000,
+                                        output_file='')
+        for img in images: # Close images to be able to move the directory
+            img.close()
+
+        os.rename(tmp_cache, self.cache_subfolder) # Just to make sure all information is there

--- a/document_loaders/pdf.py
+++ b/document_loaders/pdf.py
@@ -611,8 +611,9 @@ class OCRLoader():
 
 class PDFPlumberLoader():
     """Class to load a PDF file using pdfplumber with custom text reconstruction."""
-    def __init__(self, file_path:str, raw:bool=False):
-        self.parser = PdfPlumberParser(file_path)
+    def __init__(self, file_path:str, raw:bool=False, cache_dir: str='./.cache',
+                 keep_cache: bool = False):
+        self.parser = PdfPlumberParser(file_path, cache_dir, keep_cache)
         self.raw = raw
 
     def get_text(self, remove_headers:bool=True, boundaries:dict[str,float]=None) -> str:

--- a/document_loaders/processors.py
+++ b/document_loaders/processors.py
@@ -26,7 +26,7 @@ def remove_hyphens(text: str) -> str:
         match_end = re.match(r'^.*[a-zA-ZñÑáéíóúÁÉÍÓÚ ]-$', line)
         if match_end:
             line_numbers_end.append(line_no)
-        if line.startswith("-"):
+        elif line.startswith("-"):
             line_numbers_start.append(line_no)
 
     # Replace
@@ -87,6 +87,9 @@ def __dehyphenate_end(lines: list[str], line_no: int) -> list[str]:
     return lines
 
 def __dehyphenate_start(lines: list[str], line_no: int) -> list[str]:
+    if lines[line_no] == '':
+        return lines
+
     if lines[line_no].startswith("- "):
         word_suffix = lines[line_no].split(" ")[1]
         suffix_offset = 3

--- a/document_loaders/visitors.py
+++ b/document_loaders/visitors.py
@@ -17,7 +17,7 @@ class PageTextVisitor:
         Everything outside the square [(left, top) (right, bottom)] will be
         considered out of boundary.
         """
-        self.boundaries = (top, left, right, bottom)
+        self.boundaries = (left, top, right, bottom)
 
     def visitor_text(self, *args):
         """Store in an array all the texts that are out of bounds.
@@ -33,12 +33,14 @@ class PageTextVisitor:
         :param font_size: Specification of font sizes
         :type font_size: dict
         """
-        self.out_of_bounds_text = {}
+        if args[0].strip() == '':
+            return
+
         x = args[2][4]
         y = args[2][5]
-        if not (self.boundaries[1] <= x <= self.boundaries[3] and
-                self.boundaries[0] <= y <= self.boundaries[2]):
-            self.out_of_bounds_text.setdefault(y, []).append(args[0])
+        if not (self.boundaries[0] <= x <= self.boundaries[2] and
+                self.boundaries[3] <= y <= self.boundaries[1]):
+            self.out_of_bounds_text.setdefault(y, []).append(args[0].strip())
 
     def get_out_of_bounds_text(self):
         """Return an array of lines of text detected as out of boundaries by the visitor."""

--- a/document_splitters/detectors.py
+++ b/document_splitters/detectors.py
@@ -5,9 +5,10 @@ import re
 METADATA_REGEX = {
     'permissive_titles' : {
         'titles': {
-            2: r'^([iíÍ]ndice$|(t[iíÍ]tulo|[xiv]+|[0-9]+\. .*))',
-            3: r'^([0-9]+\.[0-9]|secci[oóÓ]n) .*',
-            4: r'^cap[iíÍ]tulo .*',
+            2: str(r'^([iíÍ]ndice$|art[iíÍ]culos? transitorios?( de reforma)?)|'
+                   r'((t[iíÍ]tulo|[xiv]+\.|[0-9]+\.) .*)$'),
+            3: r'^([0-9]+\.[0-9]|secci[oóÓ]n) .*$',
+            4: r'^cap[iíÍ]tulo .*$',
         },
         'contents': {
             5: str(
@@ -49,7 +50,7 @@ class TitleDetector:
         """Get the number of different types of titles the dector can find."""
         return len(self.metadata_regex['titles']) + 2
 
-    def get_number_of_content_tiltes(self):
+    def get_number_of_content_titles(self):
         """Get the number of different types of sections in the contents the dector can find."""
         return len(self.metadata_regex['contents'])
 

--- a/extract_info.py
+++ b/extract_info.py
@@ -167,7 +167,8 @@ class CLIController(CLI):
         elif self._args.loader == 'ocr':
             loader = OCRLoader(filename, self._args.cache_dir, self._args.keep_cache)
         elif self._args.loader == 'pdfplumber':
-            loader = PDFPlumberLoader(filename, self._args.raw)
+            loader = PDFPlumberLoader(filename, self._args.raw, self._args.cache_dir,
+                                      self._args.keep_cache)
         else:
             raise CLIException("Invalid type of loader")
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,2 +1,0 @@
-[BASIC]
-min-public-methods=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ matplotlib==3.10.3
 anytree==2.13.0
 pycryptodome==3.23.0
 pdfplumber==0.11.6
+opencv-python==4.11.0.86


### PR DESCRIPTION
- **- Now during group creating columns that pass through center are considered when number of column changes - Fixed boundaries for PyPDF files since Y-axis is inverted - Now whitespaces and breaklines are removed to compare text_out_of_bounds - Reduced the minimum space between columns - Fix writable boundaries obtention for OCR**
- **- Now the pdf page image is processed to obtaine horizontal lines that act as section separators - Fix for boundaries in pypdf files - Distance between words to be considered new columns was increased - Pdfplumber loader now uses cache to store images and process them - Changed pylintrc to .pylintrc and added more default options**
- **Fixing pylint errors**
