### PR TITLE
Adding parse params to extractor

### DIFF
--- a/document_loaders/parsers.py
+++ b/document_loaders/parsers.py
@@ -666,7 +666,7 @@ class PdfPlumberPage():
 
     def get_raw_text(self, remove_headers: bool=False, boundaries:dict[str,float]=None) -> str:
         """Return the text as returned by pdfplumber."""
-        if remove_headers:
+        if remove_headers and boundaries is not None:
             x0 = boundaries['left'] * self.page.width
             top = boundaries['top'] * self.page.height
             x1 = boundaries['right'] * self.page.width

--- a/get_embeddings.py
+++ b/get_embeddings.py
@@ -58,7 +58,7 @@ class CLIController(CLI):
 
         self.parser.add_argument('-a', '--action',
                             default='embeddings',
-                            choices=['embeddings', 'structure', 'tree'],
+                            choices=['embeddings', 'structure', 'tree', 'txt'],
                             type=str,
                             help='''
                                 Action to perform.
@@ -180,6 +180,8 @@ class CLIController(CLI):
             self.__action_structure(splitter, output)
         elif self._args.action == 'tree':
             self.__action_tree(splitter, output)
+        elif self._args.action == 'txt':
+            self.__action_txt(splitter, output)
         else:
             raise CLIException(f"Invalid action '{self._args.action}'")
 
@@ -231,6 +233,17 @@ class CLIController(CLI):
             base_filename = os.path.splitext(output)[0]
             splitter.save_tree(base_filename + '-tree.png')
             self._logger.info('File tree saved to %s-tree.png', base_filename)
+
+    def __action_txt(self, splitter:TreeSplitter, output:str):
+        self._logger.info('Generating text output')
+
+        clean_text = splitter.get_clean_text()
+
+        if self.print_to_console:
+            print(clean_text)
+        else:
+            self.__save_txt_file(output, clean_text)
+            self._logger.info('File text saved to %s', output)
 
     def __load_and_split_doc(self, filename:str) -> DataTreeSplitter:
         self._logger.info('Loading document data')

--- a/run.yml.example
+++ b/run.yml.example
@@ -6,6 +6,10 @@ db:
     database_dir: ./db
     keep_cache: True
 
+  file_settings:
+    file-with-letterhead.pdf:
+      parse_params_file: ./settings/params-bottom-letterhead.yml
+
   collections:
     NORM_001:
       embedder: all-MiniLM-L6-v2

--- a/utils/controllers.py
+++ b/utils/controllers.py
@@ -50,8 +50,11 @@ class CLI:
         """Get the logger handler."""
         return self._logger
 
-    def load_yaml(self, yaml_file: str):
+    def load_yaml(self, yaml_file: str) -> dict:
         """Loads a YAML file with options."""
+        if yaml_file == '':
+            return {}
+
         options = {}
         try:
             with open(yaml_file, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
- **Fix the validation for boundaries in Pdfplumber loader**
- **Now run_extractor can use custom settings_files for a file**
- **- Fix the line breaks without hypens were missing a letter - Now the tree is save with the original casing instead of all lowercase for the content - Now get_embeddings can output a clean text of the file considering the titles and blocks**
